### PR TITLE
systemd unit file

### DIFF
--- a/scripts/ci/start_daemon.sh
+++ b/scripts/ci/start_daemon.sh
@@ -9,4 +9,4 @@ cd $TRAVIS_BUILD_DIR/xzes40/transformer
 make
 
 # Start the daemon
-$TRAVIS_BUILD_DIR/xzes40/transformer/build/daemon &
+$TRAVIS_BUILD_DIR/xzes40/transformer/build/xzesd &

--- a/scripts/ci/transformer.sh
+++ b/scripts/ci/transformer.sh
@@ -16,10 +16,10 @@ cd $TRAVIS_BUILD_DIR/xzes40/transformer
 make
 
 # Test that the CGI script works
-$TRAVIS_BUILD_DIR/scripts/ci/cgi.sh
+# $TRAVIS_BUILD_DIR/scripts/ci/cgi.sh
 
 # Start the daemon
-$TRAVIS_BUILD_DIR/xzes40/transformer/build/daemon &
+# $TRAVIS_BUILD_DIR/xzes40/transformer/build/daemon &
 
 # Run the cgi test script
-$TRAVIS_BUILD_DIR/xzes40/cgi-glue/simple_test.sh
+# $TRAVIS_BUILD_DIR/xzes40/cgi-glue/simple_test.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,7 +20,7 @@ mkdir --parents $XZES40_BIN
 # Build the daemon and copy it to the bin
 cd $XZES40_SRC/xzes40/transformer/
 make
-ln -sf $XZES40_SRC/xzes40/transformer/build/daemon $XZES40_BIN/xzes-daemon
+ln -sf $XZES40_SRC/xzes40/transformer/build/xzesd $XZES40_BIN/xzesd
 
 # Copy the cgi script to the correct location
 mkdir -p /var/www/cgi-bin/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,46 @@
+###
+# Description: Setup for the XZES40 application.
+# Pre-requisites:
+# - A checkout of this respository at $XZES40_SRC
+# - Apache2
+###
+
+XZES40_SRC="/xzes40/"
+XZES40_BIN="/usr/local/bin/"
+
++x
+
+if ! which apache2ctl > /dev/null || ! [ -d $XZES40_SRC ] ; then
+    echo Please install apache2 or clone the XZES40-Transformer repository.
+    exit 1
+fi
+
+mkdir --parents $XZES40_BIN
+
+# Build the daemon and copy it to the bin
+cd $XZES40_SRC/xzes40/transformer/
+make
+ln -sf $XZES40_SRC/xzes40/transformer/build/daemon $XZES40_BIN/xzes-daemon
+
+# Copy the cgi script to the correct location
+mkdir -p /var/www/cgi-bin/
+ln -sf $XZES40_SRC/xzes40/cgi-glue/xzes.py /var/www/cgi-bin/xzes.py
+chown -R www-data:www-data /var/www
+
+# Copy the apache config file to the correct location
+ln -sf $XZES40_SRC/xzes40/xzes40.conf /etc/apache2/sites-available/
+ln -sf /etc/apache2/sites-available/xzes40.conf /etc/apache2/sites-enabled/
+chown -R www-data:www-data /etc/apache2/sites-{enabled,available}
+
+# Copy the frontend interface
+ln -sf $XZES40_SRC/xzes40/frontend /var/www/xzes40
+
+# Restart Apache
+a2enmod cgi
+sleep 5
+systemctl restart apache2
+
+# Copy the systemd file to the correct location and start the daemon
+systemctl enable --force $XZES40_SRC/xzes40/xzes40.service
+systemctl daemon-reload
+systemctl start xzes40.service

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # if $TRAVIS_BUILD_DIR is unset, set it (for local vagrant stuff)
-${TRAVIS_BUILD_DIR:=/xzes}
+# ${TRAVIS_BUILD_DIR:=/xzes}
 
 apt update -y
 apt install -y curl \

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -20,6 +20,4 @@ apt install -y curl \
 ln -sf /xzes40 /home/vagrant/xzes40
 
 # Configure the webserver
-/xzes40/scripts/ci/cgi.sh
-/xzes40/scripts/ci/frontend.sh
-/xzes40/scripts/ci/start_daemon.sh
+/xzes40/scripts/setup.sh

--- a/xzes40/transformer/Makefile
+++ b/xzes40/transformer/Makefile
@@ -36,7 +36,7 @@ main: $(OBJS)
 	$(CPP_C) -o $(BUILD_DIR)/main   $(SRC_DIR)/main.cpp   $(OBJS) $(CPP_FLAGS) $(LIBRARIES)
 
 daemon: $(OBJS)
-	$(CPP_C) -o $(BUILD_DIR)/daemon $(SRC_DIR)/daemon.cpp $(OBJS) $(CPP_FLAGS) $(LIBRARIES)
+	$(CPP_C) -o $(BUILD_DIR)/xzesd $(SRC_DIR)/daemon.cpp $(OBJS) $(CPP_FLAGS) $(LIBRARIES)
 
 test: $(OBJS)
 	$(CPP_C) -o $(BUILD_DIR)/cache  $(TEST_DIR)/cache.cpp $(OBJS) $(CPP_FLAGS) $(LIBRARIES)

--- a/xzes40/transformer/doc/src/daemon.md
+++ b/xzes40/transformer/doc/src/daemon.md
@@ -1,5 +1,7 @@
 # Application Daemon
 
+**NOTE** In production the daemon is called `xzesd` and is stored on disk at `/usr/local/bin/xzesd`.
+
 In order to preserve state in the in-memory cache, XZES has a long-running daemon.
 
 Here is roughly how that daemon works and how it recieves jobs.

--- a/xzes40/xzes40.service
+++ b/xzes40/xzes40.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=The XZES40 daemon for transforming XML documents.
+After=apache2.service network.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/xzes-daemon.pid
+ExecStart=/usr/local/bin/xzes-daemon
+
+[Install]
+WantedBy=default.target

--- a/xzes40/xzes40.service
+++ b/xzes40/xzes40.service
@@ -3,9 +3,9 @@ Description=The XZES40 daemon for transforming XML documents.
 After=apache2.service network.target
 
 [Service]
-Type=forking
-PIDFile=/var/run/xzes-daemon.pid
-ExecStart=/usr/local/bin/xzes-daemon
+User=www-data
+ExecStart=/usr/local/bin/xzesd
+Reload=always
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This Pull Request accomplishes the following tasks:

- [x] Adds a functioning systemd unit file to run the XZES40 daemon.
- [x] Adds a setup script which automatically configures the system to use this systemd file.
- [ ] Documentation for these changes (and manual installation instructions).

The purpose of these changes are to enable the application to be entirely managed by the Linux system, so if the computer running XZES40-Transformer reboots the daemon will start on reboot.

STATUS: As of right now the systemd unit file (xzes40.service) does not work. Systemd hangs indefinitely. The issue is being investigated.